### PR TITLE
Dev time sync

### DIFF
--- a/OpenBCI_32bit_Library.cpp
+++ b/OpenBCI_32bit_Library.cpp
@@ -277,12 +277,12 @@ boolean OpenBCI_32bit_Library::processChar(char character) {
 
 
             // DAISY MODULE COMMANDS
-            case 'c':  // use 8 channel mode
+            case OPENBCI_CHANNEL_MAX_NUMBER_8:  // use 8 channel mode
                 if(daisyPresent){
                     removeDaisy();
                 }
                 break;
-            case 'C':  // use 16 channel mode
+            case OPENBCI_CHANNEL_MAX_NUMBER_16:  // use 16 channel mode
                 if(daisyPresent == false){
                     attachDaisy();
                 }
@@ -779,7 +779,7 @@ void OpenBCI_32bit_Library::sendChannelDataWithTimeAndRawAux(void) {
 
     writeTimeCurrent(); // 4 bytes
 
-    Serial0.write(OPENBCI_EOP_TIME_SYNCED_RAW_AUX); // 0xF5
+    Serial0.write(OPENBCI_EOP_TIME_SYNCED_RAW_AUX); // 0xC5
 
     sampleCounter++;
 

--- a/OpenBCI_32bit_Library.cpp
+++ b/OpenBCI_32bit_Library.cpp
@@ -323,7 +323,9 @@ boolean OpenBCI_32bit_Library::processChar(char character) {
 
             // TIME SYNC
             case OPENBCI_TIME_SET:
-                // Send time Packet
+                // Set flag to send time packet
+                sendTimeSyncUpPacket = true;
+                timeSynced = true;
                 streamSafeTimeSendSyncSetPacket();
                 break;
 
@@ -676,6 +678,7 @@ void OpenBCI_32bit_Library::initialize(){
 
 void OpenBCI_32bit_Library::initializeVariables(void) {
     streaming = false;
+    sendTimeSyncUpPacket = false;
     timeSynced = false;
     isProcessingIncomingSettingsChannel = false;
     isProcessingIncomingSettingsLeadOff = false;
@@ -761,7 +764,12 @@ void OpenBCI_32bit_Library::sendChannelDataWithTimeAndAccel(void) {
 
     writeTimeCurrent(); // 4 bytes
 
-    Serial0.write(OPENBCI_EOP_TIME_SYNCED_ACCEL); // 0xC4
+    if (sendTimeSyncUpPacket) {
+        sendTimeSyncUpPacket = false;
+        Serial0.write(OPENBCI_EOP_ACCEL_TIME_SET); // 0xC3
+    } else {
+        Serial0.write(OPENBCI_EOP_ACCEL_TIME_SYNCED); // 0xC4
+    }
 
     sampleCounter++;
 }
@@ -779,7 +787,12 @@ void OpenBCI_32bit_Library::sendChannelDataWithTimeAndRawAux(void) {
 
     writeTimeCurrent(); // 4 bytes
 
-    Serial0.write(OPENBCI_EOP_TIME_SYNCED_RAW_AUX); // 0xC5
+    if (sendTimeSyncUpPacket) {
+        sendTimeSyncUpPacket = false;
+        Serial0.write(OPENBCI_EOP_RAW_AUX_TIME_SET); // 0xC5
+    } else {
+        Serial0.write(OPENBCI_EOP_RAW_AUX_TIME_SYNCED); // 0xC6
+    }
 
     sampleCounter++;
 

--- a/OpenBCI_32bit_Library.h
+++ b/OpenBCI_32bit_Library.h
@@ -82,6 +82,7 @@ public:
     boolean sniffMode;
     boolean streaming;
     boolean timeSynced;
+    boolean sendTimeSyncUpPacket;
     boolean isProcessingIncomingSettingsChannel;
     boolean isProcessingIncomingSettingsLeadOff;
     // boolean isProcessingIncomingTime;

--- a/OpenBCI_32bit_Library_Definitions.h
+++ b/OpenBCI_32bit_Library_Definitions.h
@@ -18,9 +18,10 @@
 #define OPENBCI_EOP_STND_ACCEL 0xC0 // End of standard stream packet
 #define OPENBCI_EOP_STND_RAW_AUX 0xC1 // End of stream packet with raw packet
 #define OPENBCI_EOP_USER_DEFINED 0xC2 // End of stream packet, user defined
-#define OPENBCI_EOP_TIME_SET 0xC3 // End of time set stream packet
-#define OPENBCI_EOP_TIME_SYNCED_ACCEL 0xC4 // End of time syned stream packet
-#define OPENBCI_EOP_TIME_SYNCED_RAW_AUX 0xC5 // End of time syned stream packet
+#define OPENBCI_EOP_ACCEL_TIME_SET 0xC3 // End of time sync up with accel stream packet
+#define OPENBCI_EOP_ACCEL_TIME_SYNCED 0xC4 // End of time syned stream packet
+#define OPENBCI_EOP_RAW_AUX_TIME_SET 0xC5 // End of time sync up stream packet
+#define OPENBCI_EOP_RAW_AUX_TIME_SYNCED 0xC6 // End of time syned stream packet
 
 //PIN CONNECTIONS
 #define ADS_DRDY 	    9   // ADS data ready pin

--- a/examples/BoardWithDigitalRead/BoardWithDigitalRead.ino
+++ b/examples/BoardWithDigitalRead/BoardWithDigitalRead.ino
@@ -3,11 +3,14 @@
 #include <OpenBCI_32Bit_Library_Definitions.h>
 
 void setup() {
-  // Bring up the OpenBCI Board
-  board.begin();
+    // Bring up the OpenBCI Board
+    board.begin();
 
-  // Notify the board we want to use aux data, this effects `::sendChannelData()`
-  board.useAux = true;
+    // Notify the board we want to use aux data, this effects `::sendChannelData()`
+    board.useAux = true;
+
+    // Set pin to input A0-A5 can be digital input
+    pinMode(17, INPUT);
 }
 
 void loop() {
@@ -23,7 +26,7 @@ void loop() {
 
         // Read from the analog sensor and store auxiliary position 0
         // take a reading from the ADC. Result range from 0 to 1023
-        board.auxData[0] = analogRead(A7);
+        board.auxData[0] = digitalRead(17);
 
         // Send standard packet with channel data and accel data
         //  includes aux data because we set `useAux` in setup()


### PR DESCRIPTION
- Reformat the time sync strategy, eliminates the need to stop the ADS while sending a time sync packet.
- Fix board with analog sensor example
- Add board with digital read example
